### PR TITLE
Enable Report Protocol mode for USB HID devices

### DIFF
--- a/HID_Arduino.ino
+++ b/HID_Arduino.ino
@@ -12,7 +12,7 @@ signed char delta[3] = {0, 0, 0};
 
 USB Usb;
 USBHub Hub(&Usb);
-HIDBoot<USB_HID_PROTOCOL_MOUSE> HidMouse(&Usb);
+HIDBoot<USB_HID_PROTOCOL_MOUSE> HidMouse(&Usb, true);
 MouseRptParser Prs;
 
 void HandleButtonChange(uint8_t prevState, uint8_t newState, uint8_t button);


### PR DESCRIPTION
Without true (Boot Protocol):
- Device limited to basic 3-byte report format
- Only provides button states and X/Y movement data
- Scroll wheel, extra buttons, and advanced features are inaccessible
- Limited to 8-bit precision for movement (-127 to 127)
- Only basic functionality available regardless of device capabilities


With true (Report Protocol):
- Device operates using its native descriptor-defined report format
- Provides access to full HID report including all available data bytes
- Enables scroll wheel functionality (vertical and horizontal)
- Makes additional buttons and features accessible
- Higher precision movement values possible (up to 16-bit)
- Allows hardware to communicate all of its capabilities