### PR TITLE
Fix: Update mouse button state even without movement

### DIFF
--- a/HID_Arduino.ino
+++ b/HID_Arduino.ino
@@ -60,7 +60,8 @@ void MouseRptParser::Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *bu
     {
         OnWheelMove(pmi);
     }
-
+    
+    prevState.mouseInfo.buttons = pmi->buttons;
     prevState.bInfo[0] = buf[0];
 }
 


### PR DESCRIPTION
Resolved an issue where button state changes weren't being detected when the mouse remained stationary. Previously, button presses were only correctly handled when accompanied by X/Y movement or wheel scrolling. Now explicitly updating prevState.mouseInfo.buttons ensures proper button state tracking regardless of mouse movement.